### PR TITLE
Do not keep a hold on connections [WIP!]

### DIFF
--- a/lib/upsert/merge_function.rb
+++ b/lib/upsert/merge_function.rb
@@ -32,11 +32,9 @@ class Upsert
       end
 
       def lookup(controller, row)
-        @lookup ||= {}
         selector_keys = row.selector.keys
         setter_keys = row.setter.keys
-        key = [controller.table_name, selector_keys, setter_keys]
-        @lookup[key] ||= new(controller, selector_keys, setter_keys, controller.assume_function_exists?)
+        new(controller, selector_keys, setter_keys, controller.assume_function_exists?)
       end
     end
 

--- a/spec/database_functions_spec.rb
+++ b/spec/database_functions_spec.rb
@@ -4,6 +4,7 @@ describe Upsert do
   describe 'database functions' do
 
     it "re-uses merge functions across connections" do
+      pending "skipped until we determine if and how to cache functions without keeping a handle to the connection"
       begin
         io = StringIO.new
         old_logger = Upsert.logger

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ ENV['DB'] ||= 'mysql'
 
 class RawConnectionFactory
   DATABASE = 'upsert_test'
-  CURRENT_USER = `whoami`.chomp
+  CURRENT_USER = ENV['DB_USER'] || `whoami`.chomp
   PASSWORD = ''
 
   case ENV['DB']

--- a/spec/threaded_spec.rb
+++ b/spec/threaded_spec.rb
@@ -1,13 +1,15 @@
 require 'spec_helper'
 describe Upsert do
+  before do
+    # first make sure to create the function separately (this is not thread-safe on its own)
+    ActiveRecord::Base.connection_pool.with_connection do |connection|
+      upsert = Upsert.new(connection, :pets, assume_function_exists: false)
+      upsert.row({name: 'xxx'}, gender: "blah")
+    end
+  end
+  
   describe "is thread-safe" do
-    it "for one-by-one use once function has been created" do
-      # first make sure to create the function separately (this is not thread-safe on its own)
-      ActiveRecord::Base.connection_pool.with_connection do |connection|
-        upsert = Upsert.new(connection, :pets, assume_function_exists: false)
-        upsert.row({name: 'xxx'}, gender: "blah")
-      end
-      
+    it "for one-by-one use once function has been created", focus: true do
       # then get a failure because of connection reuse
       assert_creates(Pet, [{:name => 'Jerry', :gender => 'neutered'}]) do
         ts = []
@@ -27,19 +29,19 @@ describe Upsert do
     it "for function creation" # to be implemented, but need to delete existing functions first!
 
     it "is safe to use batch" do
-      pending "temporarily disable to underline the main problem"
       assert_creates(Pet, [{:name => 'Jerry', :gender => 'neutered'}]) do
-        Upsert.batch($conn, :pets) do |upsert|
-          ts = []
-          10.times do
-            ts << Thread.new do
-              sleep 0.2
-              upsert.row({:name => 'Jerry'}, :gender => 'male')
-              upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+        ts = []
+        10.times do
+          ts << Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do |connection|
+              Upsert.batch(connection, :pets, assume_function_exists: true) do |upsert|
+                upsert.row({:name => 'Jerry'}, :gender => 'male')
+                upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+              end
             end
-            ts.each { |t| t.join }
           end
         end
+        ts.each { |t| t.join }
       end
     end
   end

--- a/spec/threaded_spec.rb
+++ b/spec/threaded_spec.rb
@@ -9,7 +9,7 @@ describe Upsert do
   end
   
   describe "is thread-safe" do
-    it "for one-by-one use once function has been created", focus: true do
+    it "for one-by-one use once function has been created" do
       # then get a failure because of connection reuse
       assert_creates(Pet, [{:name => 'Jerry', :gender => 'neutered'}]) do
         ts = []

--- a/spec/threaded_spec.rb
+++ b/spec/threaded_spec.rb
@@ -1,21 +1,33 @@
 require 'spec_helper'
 describe Upsert do
   describe "is thread-safe" do
-    it "is safe to use one-by-one" do
-      upsert = Upsert.new $conn, :pets
+    it "for one-by-one use once function has been created" do
+      # first make sure to create the function separately (this is not thread-safe on its own)
+      ActiveRecord::Base.connection_pool.with_connection do |connection|
+        upsert = Upsert.new(connection, :pets, assume_function_exists: false)
+        upsert.row({name: 'xxx'}, gender: "blah")
+      end
+      
+      # then get a failure because of connection reuse
       assert_creates(Pet, [{:name => 'Jerry', :gender => 'neutered'}]) do
         ts = []
         10.times do
           ts << Thread.new do
-            sleep 0.2
-            upsert.row({:name => 'Jerry'}, :gender => 'male')
-            upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+            ActiveRecord::Base.connection_pool.with_connection do |connection|
+              upsert = Upsert.new(connection, :pets, assume_function_exists: true)
+              upsert.row({:name => 'Jerry'}, :gender => 'male')
+              upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+            end
           end
-          ts.each { |t| t.join }
         end
+        ts.each { |t| t.join }
       end
     end
+    
+    it "for function creation" # to be implemented, but need to delete existing functions first!
+
     it "is safe to use batch" do
+      pending "temporarily disable to underline the main problem"
       assert_creates(Pet, [{:name => 'Jerry', :gender => 'neutered'}]) do
         Upsert.batch($conn, :pets) do |upsert|
           ts = []


### PR DESCRIPTION
Work in progress!

`Upsert.new(connection, ...)` currently caches an indirect reference to the connection in a class variable.

This is a problem in multi-threaded environments where the connection is temporarily taken from a pool and must be fully released, like in this code:

```ruby
ActiveRecord::Base.connection_pool.with_connection do |connection|
  upsert = Upsert.new(connection, :pets)
  upsert.row({name: 'Jerry'}, gender: 'male')
end
```

With the current cache, the connection is stored then reused later by another thread, after it has been given back to the pool.

This PR removes the cache completely.

Note that it hasn't been  tested in production, this is very much a work in progress to improve thread-safety of upsert.

### Points to consider

* I only ran specs with mysql `DB=mysql rspec`
* in my benchmarks, the removal of the cache does not seem to cause performance issues: it usually takes less than 1ms to prepare the merge function without the cache
* the `sequel_spec.rb` is now failing, because the `column_definitions` is not properly loaded. I suspect this is more a test issue than a real issue, but to be investigated.
