### PR TITLE
Support mysql returning column info as symbols

### DIFF
--- a/lib/upsert/column_definition/mysql.rb
+++ b/lib/upsert/column_definition/mysql.rb
@@ -6,16 +6,16 @@ class Upsert
         def all(connection, table_name)
           connection.execute("SHOW COLUMNS FROM #{connection.quote_ident(table_name)}").map do |row|
             # {"Field"=>"name", "Type"=>"varchar(255)", "Null"=>"NO", "Key"=>"PRI", "Default"=>nil, "Extra"=>""}
-            name = row['Field'] || row['COLUMN_NAME']
-            type = row['Type'] || row['COLUMN_TYPE']
-            default = row['Default'] || row['COLUMN_DEFAULT']
+            name = row['Field'] || row['COLUMN_NAME'] || row[:Field] || row[:COLUMN_NAME]
+            type = row['Type'] || row['COLUMN_TYPE'] || row[:Type] || row[:COLUMN_TYPE]
+            default = row['Default'] || row['COLUMN_DEFAULT'] || row[:Default] || row[:COLUMN_DEFAULT]
             new connection, name, type, default
           end.sort_by do |cd|
             cd.name
           end
         end
       end
-      
+
       def equality(left, right)
         "#{left} <=> #{right}"
       end


### PR DESCRIPTION
In my case, the mysql2 gem is returning column information with a Symbol-based Hash as opposed to a String-based one.  This fixes that issue :)