### PR TITLE
(enh) re-works merge function caching for thread-safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ global:
   - USERNAME=travis
     PASSWORD=
 rvm:
+  - 2.2.0
+  - 2.1.0
+  - 2.0.0
   - 1.9.3
   - 1.9.2
   - 1.8.7

--- a/lib/upsert.rb
+++ b/lib/upsert.rb
@@ -194,6 +194,7 @@ class Upsert
     end
     @connection = Connection.const_get(adapter).new self, metal
     @merge_function_class = MergeFunction.const_get adapter
+    @merge_function_cache = {}
     @assume_function_exists = options.fetch :assume_function_exists, false
   end
 
@@ -212,14 +213,20 @@ class Upsert
   #   upsert = Upsert.new Pet.connection, Pet.table_name
   #   upsert.row({:name => 'Jerry'}, :breed => 'beagle')
   #   upsert.row({:name => 'Pierre'}, :breed => 'tabby')
-  def row(selector, setter = {}, options = nil)
-    merge_function_class.execute self, Row.new(selector, setter, options)
+  def row (selector, setter = {}, options = nil)
+    row_object = Row.new(selector, setter, options)
+    merge_function(row_object).execute(row_object)
     nil
   end
 
   # @private
   def clear_database_functions
     merge_function_class.clear connection
+  end
+  
+  def merge_function (row)
+    cache_key = [row.selector.keys, row.setter.keys]
+    @merge_function_cache[cache_key] ||= merge_function_class.new(self, row.selector.keys, row.setter.keys, assume_function_exists?)
   end
 
   # @private

--- a/lib/upsert/merge_function.rb
+++ b/lib/upsert/merge_function.rb
@@ -8,11 +8,6 @@ class Upsert
     NAME_PREFIX = "upsert#{Upsert::VERSION.gsub('.', '_')}"
 
     class << self
-      def execute(controller, row)
-        merge_function = lookup controller, row
-        merge_function.execute row
-      end
-
       def unique_name(table_name, selector_keys, setter_keys)
         parts = [
           NAME_PREFIX,
@@ -30,14 +25,6 @@ class Upsert
           parts
         end
       end
-
-      def lookup(controller, row)
-        @lookup ||= {}
-        selector_keys = row.selector.keys
-        setter_keys = row.setter.keys
-        key = [controller.table_name, selector_keys, setter_keys]
-        @lookup[key] ||= new(controller, selector_keys, setter_keys, controller.assume_function_exists?)
-      end
     end
 
     attr_reader :controller
@@ -53,7 +40,7 @@ class Upsert
     end
 
     def name
-      @name ||= MergeFunction.unique_name table_name, selector_keys, setter_keys
+      @name ||= self.class.unique_name table_name, selector_keys, setter_keys
     end
 
     def connection


### PR DESCRIPTION
- Moves caching for Merge Functions to per-Upsert instance
- Fixes #37 properly
- May have additional benefits in reducing memory leaks if upserts are done many times over time
- May have very visible benefits in reducing segfaults (due to the connections no longer being shared across thread boundaries)

* * *

    threads = 10.times.map { |x|
      Thread.new {
        ActiveRecord::Base.connection_pool.with_connection { |c|
          Upsert.batch(c, :students) { |upsert|
            loop {
              Thread.current[:iterations] = 1 + (Thread.current[:iterations] || 0)
              puts "ITER #{ x }"
              upsert.row({ id: '10c273b5-4803-4af7-8149-284feb433d56' }, { gender: 0 })
              puts "ITER’d #{ x }"
            }
          }
        }
      }
    }
    
    threads.each(&:join)
