### PR TITLE
support column names with spaces in them

### DIFF
--- a/lib/upsert/merge_function.rb
+++ b/lib/upsert/merge_function.rb
@@ -13,9 +13,9 @@ class Upsert
           NAME_PREFIX,
           table_name,
           'SEL',
-          selector_keys.join('_A_'),
+          selector_keys.join('_A_').gsub(" ","_"),
           'SET',
-          setter_keys.join('_A_')
+          setter_keys.join('_A_').gsub(" ","_")
         ].join('_')
         if parts.length > MAX_NAME_LENGTH
           # maybe i should md5 instead

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -83,6 +83,13 @@ describe Upsert do
           upsert.row({:id => jerry.id}, :gender => :male)
         end
       end
+
+      it "works for column names with spaces in them" do
+        upsert = Upsert.new $conn, :people
+        assert_creates(Person, [{:"First Name" => 'Major', :"Last Name" => 'Major'}]) do
+          upsert.row({:"First Name" => 'Major'}, :"Last Name" => 'Major')
+        end
+      end
     end
     describe :batch do
       it "works for multiple rows (base case)" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -119,12 +119,19 @@ class Pet < ActiveRecord::Base
 end
 Pet.auto_upgrade!
 
+
 class Task < ActiveRecord::Base
   col :name
   col :created_at, :type => :datetime
   col :created_on, :type => :datetime
 end
 Task.auto_upgrade!
+
+class Person < ActiveRecord::Base
+  col :"First Name"
+  col :"Last Name"
+end
+Person.auto_upgrade!
 
 require 'zlib'
 require 'benchmark'


### PR DESCRIPTION
I'm trying to upsert records into a database from a CSV while using the headers from the CSV as column names... because reasons. 

Some of the headings have spaces in them and this was causing upset to error, so I patched it.

I have only really tested this on postgresql