### PR TITLE
Support Schemas

### DIFF
--- a/lib/upsert.rb
+++ b/lib/upsert.rb
@@ -231,7 +231,7 @@ class Upsert
 
   # @private
   def quoted_table_name
-    @quoted_table_name ||= connection.quote_ident(table_name.gsub('"', '').split('.'))
+    @quoted_table_name ||= table_name
   end
 
   # @private

--- a/lib/upsert.rb
+++ b/lib/upsert.rb
@@ -231,7 +231,7 @@ class Upsert
 
   # @private
   def quoted_table_name
-    @quoted_table_name ||= connection.quote_ident table_name.split('.')
+    @quoted_table_name ||= connection.quote_ident table_name.split('.').gsub('"', '')
   end
 
   # @private

--- a/lib/upsert.rb
+++ b/lib/upsert.rb
@@ -14,7 +14,7 @@ class Upsert
     # What logger to use.
     # @return [#info,#warn,#debug]
     attr_writer :logger
-    
+
     # The current logger
     # @return [#info,#warn,#debug]
     def logger
@@ -223,7 +223,7 @@ class Upsert
   def clear_database_functions
     merge_function_class.clear connection
   end
-  
+
   def merge_function(row)
     cache_key = [row.selector.keys, row.setter.keys]
     @merge_function_cache[cache_key] ||= merge_function_class.new(self, row.selector.keys, row.setter.keys, assume_function_exists?)
@@ -231,7 +231,7 @@ class Upsert
 
   # @private
   def quoted_table_name
-    @quoted_table_name ||= connection.quote_ident table_name
+    @quoted_table_name ||= connection.quote_ident table_name.split('.')
   end
 
   # @private

--- a/lib/upsert.rb
+++ b/lib/upsert.rb
@@ -231,7 +231,7 @@ class Upsert
 
   # @private
   def quoted_table_name
-    @quoted_table_name ||= connection.quote_ident table_name.gsub('"', '').split('.')
+    @quoted_table_name ||= connection.quote_ident(table_name.gsub('"', '').split('.'))
   end
 
   # @private

--- a/lib/upsert.rb
+++ b/lib/upsert.rb
@@ -231,7 +231,7 @@ class Upsert
 
   # @private
   def quoted_table_name
-    @quoted_table_name ||= connection.quote_ident table_name.split('.').gsub('"', '')
+    @quoted_table_name ||= connection.quote_ident table_name.gsub('"', '').split('.')
   end
 
   # @private

--- a/lib/upsert/column_definition/postgresql.rb
+++ b/lib/upsert/column_definition/postgresql.rb
@@ -9,7 +9,7 @@ class Upsert
 SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS sql_type, d.adsrc AS default
 FROM pg_attribute a LEFT JOIN pg_attrdef d
   ON a.attrelid = d.adrelid AND a.attnum = d.adnum
-WHERE a.attrelid = '#{connection.quote_ident(table_name)}'::regclass
+WHERE a.attrelid = '#{connection.quote_ident(table_name.gsub('"', '').split('.'))}'::regclass
 AND a.attnum > 0 AND NOT a.attisdropped
 EOS
           res.map do |row|
@@ -19,7 +19,7 @@ EOS
           end
         end
       end
-      
+
       # NOTE not using this because it can't be indexed
       # def equality(left, right)
       #   "#{left} IS NOT DISTINCT FROM #{right}"

--- a/lib/upsert/column_definition/postgresql.rb
+++ b/lib/upsert/column_definition/postgresql.rb
@@ -9,7 +9,7 @@ class Upsert
 SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS sql_type, d.adsrc AS default
 FROM pg_attribute a LEFT JOIN pg_attrdef d
   ON a.attrelid = d.adrelid AND a.attnum = d.adnum
-WHERE a.attrelid = '#{connection.quote_ident(table_name.gsub('"', '').split('.'))}'::regclass
+WHERE a.attrelid = '#{table_name}'::regclass
 AND a.attnum > 0 AND NOT a.attisdropped
 EOS
           res.map do |row|

--- a/lib/upsert/merge_function.rb
+++ b/lib/upsert/merge_function.rb
@@ -48,7 +48,7 @@ class Upsert
     end
 
     def table_name
-      controller.table_name
+      controller.table_name.gsub('"', '').gsub('.', '')
     end
 
     def quoted_table_name

--- a/lib/upsert/merge_function.rb
+++ b/lib/upsert/merge_function.rb
@@ -48,7 +48,7 @@ class Upsert
     end
 
     def table_name
-      controller.table_name.gsub('"', '').gsub('.', '')
+      controller.table_name.gsub('"', '').gsub('.', '_')
     end
 
     def quoted_table_name

--- a/lib/upsert/version.rb
+++ b/lib/upsert/version.rb
@@ -1,3 +1,3 @@
 class Upsert
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/lib/upsert/version.rb
+++ b/lib/upsert/version.rb
@@ -1,3 +1,3 @@
 class Upsert
-  VERSION = '2.1.3'
+  VERSION = '2.1.4'
 end

--- a/lib/upsert/version.rb
+++ b/lib/upsert/version.rb
@@ -1,3 +1,3 @@
 class Upsert
-  VERSION = '2.1.1'
+  VERSION = '2.1.3'
 end

--- a/lib/upsert/version.rb
+++ b/lib/upsert/version.rb
@@ -1,3 +1,3 @@
 class Upsert
-  VERSION = '2.1.4'
+  VERSION = '2.1.5'
 end

--- a/lib/upsert/version.rb
+++ b/lib/upsert/version.rb
@@ -1,3 +1,3 @@
 class Upsert
-  VERSION = '2.1.5'
+  VERSION = '2.1.6'
 end


### PR DESCRIPTION
### Support schemas.

##### Table name needs to be able to support the format `'"schema"."table_name"'` for schema inserts to work.

The `gem pg` connection adapter does not allow access to `#PG::Connection.quote_ident(array)`, only the version of the function that takes a string. This means no clean way to SQL escape the psql identity string for a table within a schema.

If you're willing to trust the table name coming in, then there's no need to escape it. In my use case I'm handling the table_name escaping with `ActiveRecord::Connection.quote_table_name(table_name)` before upserting.

Pgsql functions cannot contain `"` or `.` characters, both of which are present in table names for tables within schemas. Removing quotes and replacing `.` with `_` seems like a reasonable compromise.

If someone wants to figure out SQL escaping that would be great.