### PR TITLE
Supporting of 2.2.0 version in .travis.yml

### DIFF
--- a/upsert.gemspec
+++ b/upsert.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-expectations'
   gem.add_development_dependency 'rspec-mocks'
 
-  gem.add_development_dependency 'activerecord', '~>3'
+  gem.add_development_dependency 'activerecord', '~> 3'
   gem.add_development_dependency 'active_record_inline_schema'
   gem.add_development_dependency 'faker'
   gem.add_development_dependency 'yard'
@@ -47,7 +47,7 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency 'activerecord-jdbcpostgresql-adapter'
   else
     gem.add_development_dependency 'sqlite3'
-    gem.add_development_dependency 'mysql2'
+    gem.add_development_dependency 'mysql2', '~> 0.3.20'
     gem.add_development_dependency 'pg'
     # github-flavored markdown
     if RUBY_VERSION >= '1.9'


### PR DESCRIPTION
mysql2 version changed too; this is well-known bug of [mysql2 gem](http://stackoverflow.com/questions/32543153/ruby-on-rails-cannot-connect-to-mysql-database)