### PR TITLE
Addressing some thread safety concerns.

### DIFF
--- a/lib/upsert.rb
+++ b/lib/upsert.rb
@@ -218,11 +218,11 @@ class Upsert
   #   upsert.row({:name => 'Jerry'}, :breed => 'beagle')
   #   upsert.row({:name => 'Pierre'}, :breed => 'tabby')
   def row(selector, setter = {}, options = nil)
-    # @row_mutex.synchronize do
+    @row_mutex.synchronize do
       row_object = Row.new(selector, setter, options)
       merge_function(row_object).execute(row_object)
       nil
-    # end
+    end
   end
 
   # @private
@@ -232,10 +232,10 @@ class Upsert
 
   def merge_function(row)
     cache_key = [row.selector.keys, row.setter.keys]
-    # @merge_function_mutex.synchronize do
+    @merge_function_mutex.synchronize do
       @merge_function_cache[cache_key] ||=
         merge_function_class.new(self, row.selector.keys, row.setter.keys, assume_function_exists?)
-    # end
+    end
   end
 
   # @private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ class RawConnectionFactory
     end
     ActiveRecord::Base.establish_connection(
       :adapter => RUBY_PLATFORM == 'java' ? 'mysql' : 'mysql2',
-      :user => CURRENT_USER,
+      :username => CURRENT_USER,
       :password => PASSWORD,
       :host => '127.0.0.1',
       :database => DATABASE,

--- a/spec/threaded_spec.rb
+++ b/spec/threaded_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 describe Upsert do
+  Thread.abort_on_exception = true
   describe "is thread-safe" do
     it "is safe to use one-by-one" do
       upsert = Upsert.new $conn, :pets
@@ -7,12 +8,14 @@ describe Upsert do
         ts = []
         10.times do
           ts << Thread.new do
-            sleep 0.2
-            upsert.row({:name => 'Jerry'}, :gender => 'male')
-            upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+            ActiveRecord::Base.connection_pool.with_connection do |conn|
+              sleep 0.2
+              upsert.row({:name => 'Jerry'}, :gender => 'male')
+              upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+            end
           end
-          ts.each { |t| t.join }
         end
+        ts.each { |t| t.join(3) }
       end
     end
     it "is safe to use batch" do
@@ -21,13 +24,33 @@ describe Upsert do
           ts = []
           10.times do
             ts << Thread.new do
-              sleep 0.2
-              upsert.row({:name => 'Jerry'}, :gender => 'male')
-              upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+              ActiveRecord::Base.connection_pool.with_connection do |conn|
+                sleep 0.2
+                upsert.row({:name => 'Jerry'}, :gender => 'male')
+                upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+              end
             end
-            ts.each { |t| t.join }
+          end
+          ts.each { |t| t.join(3) }
+        end
+      end
+    end
+
+    it "is safe to use with the entire block instead the thread" do
+      assert_creates(Pet, [{:name => 'Jerry', :gender => 'neutered'}]) do
+        ts = []
+        10.times do
+          ts << Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do |conn|
+              sleep 0.2
+              Upsert.batch(conn, :pets) do |upsert|
+                upsert.row({:name => 'Jerry'}, :gender => 'male')
+                upsert.row({:name => 'Jerry'}, :gender => 'neutered')
+              end
+            end
           end
         end
+        ts.each { |t| t.join(3) }
       end
     end
   end


### PR DESCRIPTION
- Fixed the spec so it's properly multi-threaded.  Previously the threads were being joined in the loop, so they were executing in serial.
- Changed the default pool size to 20 so the threaded tests can run
- Snychronized access to running the row function (so functions aren't simultaneously created)
- Synchronized access to the row function cache
- May fix https://github.com/seamusabshere/upsert/issues/72 - given that threading leads to random errors, it may or may not be the case.
