### PR TITLE
Add UTF8 correctness spec and configure mysql to be happy with it.

### DIFF
--- a/spec/correctness_spec.rb
+++ b/spec/correctness_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 describe Upsert do
   describe 'clever correctness' do

--- a/spec/correctness_spec.rb
+++ b/spec/correctness_spec.rb
@@ -78,6 +78,18 @@ describe Upsert do
       end
     end
 
+    it "works with utf-8 data" do
+      u = Upsert.new($conn, :pets)
+      records = [
+        {:name => '你好', :home_address => '人'},
+        {:name => 'Здравствуйте', :home_address => 'человек'},
+        {:name => '😀', :home_address => '😂'},
+      ]
+      assert_creates(Pet, records) do
+        records.each { |rec| u.row(rec) }
+      end
+    end
+
     it "tells you if you request a column that doesn't exist" do
       u = Upsert.new($conn, :pets)
       lambda { u.row(:gibberish => 'ba') }.should raise_error(/invalid col/i)

--- a/spec/reserved_words_spec.rb
+++ b/spec/reserved_words_spec.rb
@@ -7,7 +7,7 @@ describe Upsert do
     end.map do |path|
       IO.readlines(path)
     end.flatten.map(&:chomp).select(&:present?).uniq
-  
+
     # make lots of AR models, each of which has 10 columns named after these words
     nasties = []
     reserved_words.each_slice(10) do |words|
@@ -18,9 +18,9 @@ describe Upsert do
       nasty = Object.const_get("Nasty#{nasties.length}")
       nasty.class_eval do
         self.primary_key = 'fake_primary_key'
-        col :fake_primary_key
+        col :fake_primary_key, limit: 191
         words.each do |word|
-          col word
+          col word, limit: 191
         end
       end
       nasties << [ nasty, words ]
@@ -28,7 +28,7 @@ describe Upsert do
     nasties.each do |nasty, _|
       nasty.auto_upgrade!
     end
-  
+
     describe "reserved words" do
       nasties.each do |nasty, words|
         it "doesn't die on reserved words #{words.join(',')}" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ class RawConnectionFactory
   when 'mysql'
     password_argument = (PASSWORD.empty?) ? "" : "-p#{PASSWORD}"
     Kernel.system %{ mysql -h 127.0.0.1 -u #{CURRENT_USER} #{password_argument} -e "DROP DATABASE IF EXISTS #{DATABASE}" }
-    Kernel.system %{ mysql -h 127.0.0.1 -u #{CURRENT_USER} #{password_argument} -e "CREATE DATABASE #{DATABASE} CHARSET utf8" }
+    Kernel.system %{ mysql -h 127.0.0.1 -u #{CURRENT_USER} #{password_argument} -e "CREATE DATABASE #{DATABASE} CHARSET utf8mb4 COLLATE utf8mb4_general_ci" }
     if RUBY_PLATFORM == 'java'
       CONFIG = "jdbc:mysql://127.0.0.1/#{DATABASE}?user=#{CURRENT_USER}&password=#{PASSWORD}"
       require 'jdbc/mysql'
@@ -58,12 +58,20 @@ class RawConnectionFactory
     else
       require 'mysql2'
       def new_connection
-        config = { :username => CURRENT_USER, :database => DATABASE, :host => "127.0.0.1" }
+        config = { :username => CURRENT_USER, :database => DATABASE, :host => "127.0.0.1", :encoding => 'utf8mb4' }
         config.merge!(:password => PASSWORD) unless PASSWORD.empty?
         Mysql2::Client.new config
       end
     end
-    ActiveRecord::Base.establish_connection "#{RUBY_PLATFORM == 'java' ? 'mysql' : 'mysql2'}://#{CURRENT_USER}:#{PASSWORD}@127.0.0.1/#{DATABASE}"
+    ActiveRecord::Base.establish_connection(
+      :adapter => RUBY_PLATFORM == 'java' ? 'mysql' : 'mysql2',
+      :user => CURRENT_USER,
+      :password => PASSWORD,
+      :host => '127.0.0.1',
+      :database => DATABASE,
+      :encoding => 'utf8mb4'
+    )
+    ActiveRecord::Base.connection.execute "SET NAMES utf8mb4 COLLATE utf8mb4_general_ci"
 
   when 'sqlite3'
     CONFIG = { :adapter => 'sqlite3', :database => 'file::memory:?cache=shared' }
@@ -105,7 +113,7 @@ else
 end
 
 class Pet < ActiveRecord::Base
-  col :name
+  col :name, limit: 191 # utf8mb4 in mysql requirement
   col :gender
   col :spiel
   col :good, :type => :boolean
@@ -117,9 +125,8 @@ class Pet < ActiveRecord::Base
   col :home_address, :type => :text
   if ENV['DB'] == 'postgresql'
     col :tsntz, :type => 'timestamp without time zone'
-  else
-    add_index :name, :unique => true
   end
+  add_index :name, :unique => true
 end
 if ENV['DB'] == 'postgresql' && UNIQUE_CONSTRAINT
   begin
@@ -219,6 +226,7 @@ module SpecHelper
     expected_records.each do |selector, setter|
       setter ||= {}
       found = model.where(selector).map { |record| record.attributes.except('id') }
+      expect(found).to_not be_empty, { :selector => selector, :setter => setter }.inspect
       expected = [ selector.stringify_keys.merge(setter.stringify_keys) ]
       compare_attribute_sets expected, found
     end


### PR DESCRIPTION
This should verify that #49 isn't caused on our end.  There are a lot of potential pitfalls with UTF8 and older versions of MySQL, though, so we may want to add a note to the README about it.

Reference:
- http://pjambet.github.io/blog/emojis-and-mysql/
- https://github.com/rails/rails/issues/9855
- http://stackoverflow.com/questions/18208460/how-to-store-4-byte-character-in-mysql-5-5-using-ruby-mysql2-gem
- http://dev.mysql.com/doc/refman/5.7/en/charset-connection.html
- https://airbladesoftware.com/notes/fixing-mysql-illegal-mix-of-collations/
- https://mathiasbynens.be/notes/mysql-utf8mb4
