### PR TITLE
Add check and fix for Postgres and transactions.

### DIFF
--- a/lib/upsert/connection/Java_OrgPostgresqlJdbc4_Jdbc4Connection.rb
+++ b/lib/upsert/connection/Java_OrgPostgresqlJdbc4_Jdbc4Connection.rb
@@ -10,6 +10,11 @@ class Upsert
       def quote_ident(k)
         DOUBLE_QUOTE + k.to_s.gsub(DOUBLE_QUOTE, '""') + DOUBLE_QUOTE
       end
+
+      def in_transaction?
+        # https://github.com/kares/activerecord-jdbc-adapter/commit/4d6e0e0c52d12b0166810dffc9f898141a23bee6
+        ![0, 4].include?(metal.get_transaction_state)
+      end
     end
   end
 end

--- a/lib/upsert/connection/PG_Connection.rb
+++ b/lib/upsert/connection/PG_Connection.rb
@@ -21,6 +21,10 @@ class Upsert
       def binary(v)
         { :value => v.value, :format => 1 }
       end
+
+      def in_transaction?
+        ![PG::PQTRANS_IDLE, PG::PQTRANS_UNKNOWN].include?(metal.transaction_status)
+      end
     end
   end
 end

--- a/lib/upsert/connection/jdbc.rb
+++ b/lib/upsert/connection/jdbc.rb
@@ -84,6 +84,10 @@ class Upsert
         statement.close
         result
       end
+
+      def in_transaction?
+        raise "Not implemented"
+      end
     end
   end
 end

--- a/spec/active_record_upsert_spec.rb
+++ b/spec/active_record_upsert_spec.rb
@@ -11,6 +11,16 @@ describe Upsert do
           Pet.upsert({:name => 'Jerry'}, :good => true)
         end
       end
+
+      it "doesn't fail inside a transaction" do
+        Upsert.clear_database_functions(Pet.connection)
+        expect {
+          Pet.transaction do
+            Pet.upsert({name: 'Simba'}, good: true)
+          end
+        }.to_not raise_error
+        expect(Pet.first.name).to eq('Simba')
+      end
     end
   end
 end

--- a/spec/database_functions_spec.rb
+++ b/spec/database_functions_spec.rb
@@ -98,6 +98,5 @@ describe Upsert do
         Upsert.logger = old_logger
       end
     end
-
   end
 end if %w{ postgresql mysql }.include?(ENV['DB'])


### PR DESCRIPTION
The query is blindly called without checking to see if the DB function exists.  This was causing issues in transactions, even though we were accounting for the issue client-side.  The reason this fix is temporary is due to it being 10-20% slower than before, and hopefully a faster solution can be found.
