### PR TITLE
Add ability to upsert tables in schemas

### DIFF
--- a/lib/upsert/connection/PG_Connection.rb
+++ b/lib/upsert/connection/PG_Connection.rb
@@ -15,7 +15,11 @@ class Upsert
       end
 
       def quote_ident(k)
-        metal.quote_ident k.to_s
+        if k.include?('.')
+          k.split('.').map(&method(:quote_ident)).join('.')
+        else
+          metal.quote_ident k.to_s
+        end
       end
 
       def binary(v)

--- a/lib/upsert/merge_function.rb
+++ b/lib/upsert/merge_function.rb
@@ -8,8 +8,14 @@ class Upsert
     NAME_PREFIX = "upsert#{Upsert::VERSION.gsub('.', '_')}"
 
     class << self
-      def unique_name(table_name, selector_keys, setter_keys)
+      def unique_name(table_name, selector_keys, setter_keys, schema_name = nil)
+        schema_name, table_name = if table_name.include?('.')
+                                    table_name.split('.')
+                                  else
+                                    [schema_name, table_name]
+                                  end
         parts = [
+          schema_name,
           NAME_PREFIX,
           table_name,
           'SEL',


### PR DESCRIPTION
When I tried to use this gem to upsert some tables in schemas in
Postgres, I found that it was throwing errors. I've patched this gem to
allow using tables in schemas. I have no real experience with the other
supported databases, so I'm not sure how these changes can (or should)
propogate to those other databases. For now, though, this allows me to
use this gem!

Closes #53 