### PR TITLE
Adding license info to the gemspec.

### DIFF
--- a/upsert.gemspec
+++ b/upsert.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |gem|
   gem.description   = t
   gem.summary       = t
   gem.homepage      = "https://github.com/seamusabshere/upsert"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.