### PR TITLE
Fix for Upsert calling non-existent method setInteger in JRuby 9.2.0.0 and later

### DIFF
--- a/lib/upsert/connection/jdbc.rb
+++ b/lib/upsert/connection/jdbc.rb
@@ -24,6 +24,7 @@ class Upsert
         'TrueClass'  => 'setBoolean',
         'FalseClass' => 'setBoolean',
         'Fixnum'     => 'setInt',
+        'Integer'    => 'setInt',
       )
 
       def binary(v)


### PR DESCRIPTION
My testing setup:

- Upsert 2.2.1
- Rails 4.2.10
- activerecord-jdbcpostgresql-adapter 1.3.24
- jdbc-postgres 9.4.1206
- JRuby 9.2.0.0
- Postgres 10.3

The type for integer values changed in Ruby 2.5 and JRuby 9.2.0.0.  Originally they were of type `Fixnum`:

```
irb(main):001:0> RUBY_DESCRIPTION
=> "jruby 9.1.15.0 (2.3.3) 2017-12-07 929fde8 Java HotSpot(TM) 64-Bit Server VM 25.66-b17 on 1.8.0_66-b17 +jit [darwin-x86_64]"
irb(main):002:0> 1.class
=> Fixnum
```

But now they're of type `Integer`:

```
irb(main):001:0> RUBY_DESCRIPTION
=> "jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 Java HotSpot(TM) 64-Bit Server VM 25.66-b17 on 1.8.0_66-b17 +jit [darwin-x86_64]"
irb(main):002:0> 1.class
=> Integer
```

The JDBC connection module looks at the type of passed values to determine which setter to use, and `Fixnum` is explicitly mapped to `setInt`.  However, `Integer` isn't explicitly mapped, and so the setter is computed as `setInteger`, which doesn't exist.  Stack trace:

```
2018-07-17T19:07:39.551Z 9219 TID-1h9 WARN: NoMethodError: undefined method `setInteger' for #<Java::OrgPostgresqlJdbc4::Jdbc4PreparedStatement:0x55a21a53>
2018-07-17T19:07:39.551Z 9219 TID-1h9 WARN: /opt/cloudops/dm/shared/bundle/jruby/2.5.0/gems/upsert-2.2.1/lib/upsert/connection/jdbc.rb:54:in `block in execute'
org/jruby/RubyArray.java:1801:in `each'
org/jruby/RubyEnumerable.java:1180:in `each_with_index'
/opt/cloudops/dm/shared/bundle/jruby/2.5.0/gems/upsert-2.2.1/lib/upsert/connection/jdbc.rb:38:in `execute'
/opt/cloudops/dm/shared/bundle/jruby/2.5.0/gems/upsert-2.2.1/lib/upsert/merge_function/Java_OrgPostgresqlJdbc4_Jdbc4Connection.rb:16:in `execute_parameterized'
/opt/cloudops/dm/shared/bundle/jruby/2.5.0/gems/upsert-2.2.1/lib/upsert/merge_function/postgresql.rb:70:in `pg_function'
/opt/cloudops/dm/shared/bundle/jruby/2.5.0/gems/upsert-2.2.1/lib/upsert/merge_function/postgresql.rb:53:in `execute'
/opt/cloudops/dm/shared/bundle/jruby/2.5.0/gems/upsert-2.2.1/lib/upsert.rb:219:in `row'
/opt/cloudops/dm/releases/20180717180937/app/services/tag_manager.rb:52:in `block in update_service'
```

My solution is to add a mapping so `Integer` is mapped to `setInt`.  I'm using this patch on my staging systems, and the issue seems to have been corrected with no side effects.  I was unable to figure out how to set up database to run your test suite though - sorry.