### PR TITLE
warn when pg is not using the native query

### DIFF
--- a/lib/upsert/merge_function/postgresql.rb
+++ b/lib/upsert/merge_function/postgresql.rb
@@ -107,7 +107,11 @@ class Upsert
       end
 
       def use_pg_native?
-        server_version >= 95 && unique_index_on_selector?
+        return @use_pg_native if defined?(@use_pg_native)
+
+        @use_pg_native = server_version >= 95 && unique_index_on_selector?
+        Upsert.logger.warn "[upsert] WARNING: Not using native PG CONFLICT / UPDATE" unless @use_pg_native
+        @use_pg_native
       end
 
       def server_version


### PR DESCRIPTION
it would be nice if we could include a link to documentation on how to fix this problem either in github wiki or readme file?