### PR TITLE
fix uninitialized constant by requiring the path in Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - mysql-client-core-5.6
       - mysql-client-5.6
 rvm:
+  - 2.6
   - 2.3
   - 2.2
   - 2.1

--- a/lib/upsert/connection/Java_OrgPostgresqlJdbc4_Jdbc4Connection.rb
+++ b/lib/upsert/connection/Java_OrgPostgresqlJdbc4_Jdbc4Connection.rb
@@ -1,4 +1,5 @@
 require 'upsert/connection/jdbc'
+require 'upsert/connection/postgresql'
 
 class Upsert
   class Connection

--- a/lib/upsert/connection/PG_Connection.rb
+++ b/lib/upsert/connection/PG_Connection.rb
@@ -1,3 +1,5 @@
+require 'upsert/connection/postgresql'
+
 class Upsert
   class Connection
     # @private


### PR DESCRIPTION
I reported the [issue](https://github.com/seamusabshere/upsert/issues/113) earlier, where I was having issues with loading the path correctly. To fix it I have used `require` to load the path. Can't think of better way like lazy loads, etc. Wanted to keep it simple. 

I am on the process of upgrading our product to Ruby 2.6, so if this could be reviewed earlier then I would appreciate it a lot. Thank-you.