### PR TITLE
Take a stab at fixing apostrophe escaping.

### DIFF
--- a/lib/upsert/connection/postgresql.rb
+++ b/lib/upsert/connection/postgresql.rb
@@ -9,7 +9,7 @@ class Upsert
           '{' + v.map do |vv|
             vv = vv.to_s.dup
             vv.gsub! /\\/, '\&\&'
-            vv.gsub! /'/, "''"
+            vv.gsub! /'/, "\'"
             vv.gsub! /"/, '\"'
             %{"#{vv}"}
           end.join(',') + '}'


### PR DESCRIPTION
The previous implementation would persist double apostrophes. I suspect
this may have been broken by a new major release of postgres in the 6+
years since it was written in https://github.com/tlconnor/activerecord-postgres-array

Fixes #120 