### PR TITLE
Remove reference to deprecated `adsrc` column

### DIFF
--- a/lib/upsert/column_definition/postgresql.rb
+++ b/lib/upsert/column_definition/postgresql.rb
@@ -6,7 +6,7 @@ class Upsert
         # activerecord-3.2.5/lib/active_record/connection_adapters/postgresql_adapter.rb#column_definitions
         def all(connection, quoted_table_name)
           res = connection.execute <<-EOS
-  SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS sql_type, d.adsrc AS default
+  SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS sql_type, pg_get_expr(adbin, adrelid) AS default
   FROM pg_attribute a LEFT JOIN pg_attrdef d
   ON a.attrelid = d.adrelid AND a.attnum = d.adnum
   WHERE a.attrelid = '#{quoted_table_name}'::regclass


### PR DESCRIPTION
This came up while testing Postgresql 12 raising the following error:

```ruby
PG::UndefinedColumn: ERROR:  column d.adsrc does not exist
LINE 1: ...format_type(a.atttypid, a.atttypmod) AS sql_type, d.adsrc AS...
```
The column `adsrc` had a deprecation notice since v8.0 (https://www.postgresql.org/docs/8.0/catalog-pg-attrdef.html) and was removed in v12.0.

All tests are passing:
<img width="901" alt="Screenshot 2019-12-06 09 25 00" src="https://user-images.githubusercontent.com/8424/70312126-e0e40180-180a-11ea-8bdc-ad3e22b86c1b.png">

Fixes issue #130 